### PR TITLE
Redefinition of 'RCTMethodInfo'

### DIFF
--- a/ios/RNNeteaseIm/RNNeteaseIm/ReactNativePermissions.h
+++ b/ios/RNNeteaseIm/RNNeteaseIm/ReactNativePermissions.h
@@ -6,10 +6,10 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if __has_include("RCTBridgeModule.h")
-  #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
   #import <React/RCTBridgeModule.h>
+#elif __has_include("RCTBridgeModule.h")
+  #import "RCTBridgeModule.h"
 #endif
 
 @interface ReactNativePermissions : NSObject <RCTBridgeModule>


### PR DESCRIPTION
升级到 react-native@0.49.5 以后，出现 https://github.com/facebook/react-native/issues/15775 这个问题，调整顺序后解决。