### PR TITLE
Avoid mix of module.exports and import

### DIFF
--- a/Utils.js
+++ b/Utils.js
@@ -85,7 +85,6 @@ class Utils {
         RNNeteaseIm.setupWebViewUserAgent();
     }
 
- }
+}
 
-module.exports = new Utils();
-
+export default new Utils();

--- a/im/Friend.js
+++ b/im/Friend.js
@@ -134,4 +134,4 @@ class Friend {
         return RNNeteaseIm.removeFromBlackList(contactId);
     }
 }
-module.exports = new Friend();
+export default new Friend();

--- a/im/Session.js
+++ b/im/Session.js
@@ -301,4 +301,4 @@ class Session {
         }
     }
 }
-module.exports = new Session();
+export default new Session();

--- a/im/SystemMsg.js
+++ b/im/SystemMsg.js
@@ -133,4 +133,4 @@ class SystemMsg {
         return RNNeteaseIm.resetSystemMessageUnreadCount();
     }
 }
-module.exports = new SystemMsg();
+export default new SystemMsg();

--- a/im/Team.js
+++ b/im/Team.js
@@ -212,4 +212,4 @@ class Team {
         return RNNeteaseIm.updateTeamName(teamId, teamName);
     }
 }
-module.exports = new Team();
+export default new Team();


### PR DESCRIPTION
同一个文件里混合使用 import 和 module.exports 在 webpack 新版本打包时会出错：
```
Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'
```

一般 require 和 module.exports 一起使用，而 import 和 export 一起用。