### PR TITLE
Fix `Argument list too long: recursive header expansion failed`

### DIFF
--- a/ios/RNNeteaseIm/RNNeteaseIm.xcodeproj/project.pbxproj
+++ b/ios/RNNeteaseIm/RNNeteaseIm.xcodeproj/project.pbxproj
@@ -508,7 +508,7 @@
 				GCC_PREFIX_HEADER = RNNeteaseIm/PrefixHeader.pch;
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../react-native/React/**",
-					"$(SRCROOT)/../../../../ios/Pods/**",
+					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -523,7 +523,7 @@
 				GCC_PREFIX_HEADER = RNNeteaseIm/PrefixHeader.pch;
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../../react-native/React/**",
-					"$(SRCROOT)/../../../../ios/Pods/**",
+					"$(SRCROOT)/../../../../ios/Pods/Headers/Public/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
路径参数太多导致编译错误，改为更精确地目录。